### PR TITLE
Branch_FixRoutes_RootPage

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  root 'blogs#index'
   get 'blogs' => 'blogs#index'
   resources :users, only: [:edit, :update]
 end


### PR DESCRIPTION
・routesの修正
サインアップのURLでもpublicフォルダ配下のindexファイルを参照してしまうため、
root 'blogs#index'を削除