### PR TITLE
Branch_PageLink_SignUpAndIn

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,9 +18,15 @@
   .nav-wrapper
     %a.brand-logo{:href => "#"} Logo
     %ul#nav-mobile.right.hide-on-med-and-down
-      %li
-        %a{:href => "badges.html"} New
-      %li
-        %a{:href => "collapsible.html"} JavaScript
+      - if user_signed_in?
+        %li
+          %a{:href => "badges.html"} New
+        %li
+          = link_to "sign out", destroy_user_session_path, method: :delete
+      - else
+        %li
+          %a{:href => "badges.html"} New
+        %li
+          = link_to "sign in", new_session_path(resource_name)
 
     = yield


### PR DESCRIPTION
・indexページのヘッダー部分の修正
・サインインしていない場合、サインインを表示
・サインインしている場合、サインアウトを表示
現状、サインアウトしている状態でページを開くとサインイン画面が表示されるが、
レイアウトが崩れている（cssが適用されていない）
<img width="1230" alt="スクリーンショット 2019-04-24 22 47 59" src="https://user-images.githubusercontent.com/47979613/56664433-08a2b100-66e3-11e9-829a-061b93561543.png">
<img width="1230" alt="スクリーンショット 2019-04-24 22 47 33" src="https://user-images.githubusercontent.com/47979613/56664434-08a2b100-66e3-11e9-9504-180c16f98f0d.png">

